### PR TITLE
fix グループ一覧 の文言が消えてたのを修正

### DIFF
--- a/frontend/src/features/appLayout/components/GroupSwitcher.tsx
+++ b/frontend/src/features/appLayout/components/GroupSwitcher.tsx
@@ -134,7 +134,10 @@ export function GroupSwitcher({ currentGroupId, groups, onChange }: Props) {
             ))
           )}
         </DropdownMenuGroup>
-        <MenuItemWithIcon icon={<List className="mr-2 h-4 w-4" />} title="" />
+        <MenuItemWithIcon
+          icon={<List className="mr-2 h-4 w-4" />}
+          title="グループ一覧"
+        />
         <MenuItemWithIcon
           // {/* TODO:新規作成の処理を追加 */}
           icon={<CirclePlus className="mr-2 h-4 w-4" />}


### PR DESCRIPTION
きえてた
<img width="311" alt="image" src="https://github.com/user-attachments/assets/238667a2-02a5-4ff7-8f99-cad3aea73ee1">
