### PR TITLE
タイムラインの予定の開始時間をドラッグで編集できるように

### DIFF
--- a/frontend/src/app/(app)/(calendar)/calendar/edit/page.tsx
+++ b/frontend/src/app/(app)/(calendar)/calendar/edit/page.tsx
@@ -17,17 +17,7 @@ import { useOptimisticSchedules } from "~/hooks/useOptimisticSchedules";
 import { db } from "~/lib/firebase";
 import { defaultConverter } from "~/lib/firestore/firestore";
 import { DBEventPoolItem } from "~/lib/firestore/utils";
-
-export const getEndDroppingDate = (
-  currentDate: Date,
-  startMinute: number,
-  duration: number
-) => {
-  const endMinutes = startMinute + duration;
-  const endTime = new Date(currentDate);
-  endTime.setHours(Math.floor(endMinutes / 60), endMinutes % 60);
-  return endTime;
-};
+import { getEndDroppingDate } from "~/features/dayTimeline/utils/getEndDroppingDate";
 
 export default function Page() {
   const [events, setEvents] = useState<DBEventPoolItem[]>([]);

--- a/frontend/src/app/(app)/(calendar)/calendar/page.tsx
+++ b/frontend/src/app/(app)/(calendar)/calendar/page.tsx
@@ -1,13 +1,17 @@
+"use client";
+
+import { useRef } from "react";
 import { CardBodyWithLeftSidebar } from "~/features/appLayout/CardBodyWithLeftSidebar";
 import PrivateScheduleDayTimeline from "~/features/dayTimeline/PrivateScheduleDayTimeline";
 import { ViewerLeftSideBar } from "~/features/leftSidebar/ViewerLeftSidebar";
 
 export default function Page() {
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
   return (
     <CardBodyWithLeftSidebar
       leftSidebar={<ViewerLeftSideBar title="カレンダー" subTitle="あなたの" />}
     >
-      <PrivateScheduleDayTimeline />
+      <PrivateScheduleDayTimeline scrollAreaRef={scrollAreaRef} />
     </CardBodyWithLeftSidebar>
   );
 }

--- a/frontend/src/app/tailwind.css
+++ b/frontend/src/app/tailwind.css
@@ -53,7 +53,7 @@ body {
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
+    --radius: 0.75rem;
   }
   .dark {
     --background: 224 71.4% 4.1%;

--- a/frontend/src/features/dayTimeline/PrivateScheduleDayTimeline.tsx
+++ b/frontend/src/features/dayTimeline/PrivateScheduleDayTimeline.tsx
@@ -4,7 +4,7 @@ import DateSwitcher from "../timeline/DateSwitcher";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Timeline } from "../timeline/Timeline";
 import { useCalendarSession } from "~/hooks/useCalendarSession";
-import { RefCallback, UIEventHandler } from "react";
+import { UIEvent, UIEventHandler, useCallback, useRef } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { useTimelineSettings } from "~/hooks/useTimelineSettings";
 import TimelineSchedules from "./components/TimelineSchedules";
@@ -12,7 +12,7 @@ import { useOptimisticSchedules } from "~/hooks/useOptimisticSchedules";
 
 interface PrivateScheduleDayTimelineProps {
   onScroll?: UIEventHandler<HTMLDivElement>;
-  setScrollAreaRef?: RefCallback<HTMLDivElement>;
+  scrollAreaRef: React.RefObject<HTMLDivElement>;
 }
 
 const PrivateScheduleDayTimeline = (props: PrivateScheduleDayTimelineProps) => {
@@ -20,18 +20,34 @@ const PrivateScheduleDayTimeline = (props: PrivateScheduleDayTimelineProps) => {
   const { setNodeRef } = useDroppable({ id: "droppable-timeline" });
   const { timelineSettings } = useTimelineSettings();
   const { optimisticSchedules } = useOptimisticSchedules();
+  const onScrollForDndEditInTimeline =
+    useRef<UIEventHandler<HTMLDivElement> | null>(null);
+
+  const handleScroll = useCallback(
+    (e: UIEvent<HTMLDivElement>) => {
+      if (onScrollForDndEditInTimeline.current) {
+        onScrollForDndEditInTimeline.current(e);
+      }
+      if (props.onScroll) {
+        props.onScroll(e);
+      }
+    },
+    [onScrollForDndEditInTimeline, props]
+  );
 
   return (
     <div className="relative flex flex-col size-full px-6">
       <ScrollArea
         className="size-full"
-        onScroll={props.onScroll}
-        ref={props.setScrollAreaRef}
+        onScroll={handleScroll}
+        ref={props.scrollAreaRef}
       >
         <div className="my-6 mr-3 relative" ref={setNodeRef}>
           <TimelineSchedules
             schedules={optimisticSchedules}
             currentDate={calendarSession.currentDate}
+            scrollAreaRef={props.scrollAreaRef}
+            handleScrollStateForDndEditInTimeline={onScrollForDndEditInTimeline}
           />
           <Timeline
             itemHeight={timelineSettings.gridHeight}

--- a/frontend/src/features/dayTimeline/components/DayTimelineSchedule.tsx
+++ b/frontend/src/features/dayTimeline/components/DayTimelineSchedule.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 import { Schedule } from "~/models/types/schedule";
 import { EventPoolItem } from "~/models/types/event_pool_item";
 import { useTimelineSettings } from "~/hooks/useTimelineSettings";
-import { forwardRef, HTMLAttributes } from "react";
+import { forwardRef, HTMLAttributes, useState } from "react";
 import { Popover } from "@radix-ui/react-popover";
 import { PopoverTrigger } from "~/components/ui/popover";
 import DayTimelineScheduleDetails from "./DayTimelineScheduleDetails";
@@ -48,12 +48,18 @@ export const DayTimelineSchedule = forwardRef<
     (duration / (timelineSettings.gridInterval * 60)) *
     timelineSettings.gridHeight;
 
+  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+
   return (
     <div ref={ref} {...rest}>
-      <Popover>
+      <Popover onOpenChange={setIsDetailsOpen}>
         <PopoverTrigger className="w-full">
           <Card
-            className={clsx(isDragging && "shadow-lg")}
+            className={clsx(
+              isDragging && "shadow-lg",
+              "transition-all duration-100",
+              isDetailsOpen ? "shadow-lg" : "shadow-sm"
+            )}
             style={{
               height: `${height}px`,
               minHeight: "16px",

--- a/frontend/src/features/dayTimeline/components/DayTimelineSchedule.tsx
+++ b/frontend/src/features/dayTimeline/components/DayTimelineSchedule.tsx
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import { Schedule } from "~/models/types/schedule";
 import { EventPoolItem } from "~/models/types/event_pool_item";
 import { useTimelineSettings } from "~/hooks/useTimelineSettings";
+import { forwardRef, HTMLAttributes } from "react";
 
 export type ScheduleEvent = Schedule &
   EventPoolItem & {
@@ -23,10 +24,17 @@ const formatTime = (date: Date) => {
   });
 };
 
-export const DayTimelineSchedule = ({
-  schedule,
-  isDragging,
-}: DayTimelineEventProps) => {
+export const DayTimelineSchedule = forwardRef<
+  HTMLDivElement,
+  DayTimelineEventProps
+>(function DayTimelineSchedule(
+  {
+    schedule,
+    isDragging,
+    ...rest
+  }: DayTimelineEventProps & HTMLAttributes<HTMLDivElement>,
+  ref
+) {
   const { timelineSettings } = useTimelineSettings();
 
   const duration =
@@ -38,7 +46,7 @@ export const DayTimelineSchedule = ({
     timelineSettings.gridHeight;
 
   return (
-    <div>
+    <div ref={ref} {...rest}>
       <Card
         className={clsx(isDragging && "shadow-lg")}
         style={{
@@ -67,4 +75,4 @@ export const DayTimelineSchedule = ({
       </Card>
     </div>
   );
-};
+});

--- a/frontend/src/features/dayTimeline/components/DayTimelineSchedule.tsx
+++ b/frontend/src/features/dayTimeline/components/DayTimelineSchedule.tsx
@@ -6,6 +6,9 @@ import { Schedule } from "~/models/types/schedule";
 import { EventPoolItem } from "~/models/types/event_pool_item";
 import { useTimelineSettings } from "~/hooks/useTimelineSettings";
 import { forwardRef, HTMLAttributes } from "react";
+import { Popover } from "@radix-ui/react-popover";
+import { PopoverTrigger } from "~/components/ui/popover";
+import DayTimelineScheduleDetails from "./DayTimelineScheduleDetails";
 
 export type ScheduleEvent = Schedule &
   EventPoolItem & {
@@ -47,32 +50,37 @@ export const DayTimelineSchedule = forwardRef<
 
   return (
     <div ref={ref} {...rest}>
-      <Card
-        className={clsx(isDragging && "shadow-lg")}
-        style={{
-          height: `${height}px`,
-          minHeight: "16px",
-        }}
-      >
-        <CardContent className="py-4 px-5">
-          <div className="flex flex-col gap-2">
-            <h1 className="text-sm font-bold">{schedule.title}</h1>
+      <Popover>
+        <PopoverTrigger className="w-full">
+          <Card
+            className={clsx(isDragging && "shadow-lg")}
+            style={{
+              height: `${height}px`,
+              minHeight: "16px",
+            }}
+          >
+            <CardContent className="py-4 px-5">
+              <div className="flex flex-col gap-2 items-start">
+                <h1 className="text-sm font-bold">{schedule.title}</h1>
 
-            <div className="flex flex-col gap-1.5 ">
-              {schedule.location_text !== "" && (
-                <PropsWithIcon
-                  icon={<Map size={14} />}
-                  value={schedule.location_text}
-                />
-              )}
-              <PropsWithIcon
-                icon={<Clock size={14} />}
-                value={formatTime(schedule.start_time.toDate())}
-              />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+                <div className="flex flex-col gap-1.5 ">
+                  {schedule.location_text !== "" && (
+                    <PropsWithIcon
+                      icon={<Map size={14} />}
+                      value={schedule.location_text}
+                    />
+                  )}
+                  <PropsWithIcon
+                    icon={<Clock size={14} />}
+                    value={formatTime(schedule.start_time.toDate())}
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </PopoverTrigger>
+        <DayTimelineScheduleDetails scheduleEvent={schedule} />
+      </Popover>
     </div>
   );
 });

--- a/frontend/src/features/dayTimeline/components/DayTimelineScheduleDetails.tsx
+++ b/frontend/src/features/dayTimeline/components/DayTimelineScheduleDetails.tsx
@@ -1,0 +1,24 @@
+import SmallTitleWithIcon from "~/components/common/SmallTitleWithIcon";
+import { PopoverContent } from "~/components/ui/popover";
+import { ScheduleEvent } from "./DayTimelineSchedule";
+
+interface DayTimelineScheduleDetailsProps {
+  scheduleEvent: ScheduleEvent;
+}
+
+const DayTimelineScheduleDetails = (props: DayTimelineScheduleDetailsProps) => {
+  return (
+    <PopoverContent className="w-80" side={"right"} sideOffset={10}>
+      {/* TODO: 編集とかできるようにする */}
+      <div className="flex flex-col gap-2">
+        <SmallTitleWithIcon title={props.scheduleEvent.title} />
+        <div>{props.scheduleEvent.description}</div>
+        <div>{props.scheduleEvent.location_text}</div>
+        <div>{props.scheduleEvent.preparation_task}</div>
+        <div>{props.scheduleEvent.notes}</div>
+      </div>
+    </PopoverContent>
+  );
+};
+
+export default DayTimelineScheduleDetails;

--- a/frontend/src/features/dayTimeline/components/DraggableDayTimelineSchedule.tsx
+++ b/frontend/src/features/dayTimeline/components/DraggableDayTimelineSchedule.tsx
@@ -1,0 +1,30 @@
+import { useDraggable } from "@dnd-kit/core";
+import clsx from "clsx";
+import { DayTimelineSchedule, ScheduleEvent } from "./DayTimelineSchedule";
+
+interface DraggableTimelineScheduleProps {
+  id: string;
+  schedule: ScheduleEvent;
+}
+
+const DraggableDayTimelineSchedule = (
+  props: DraggableTimelineScheduleProps
+) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: props.id,
+    data: { schedule: props.schedule },
+  });
+
+  return (
+    <div className={clsx(isDragging && "opacity-50")}>
+      <DayTimelineSchedule
+        ref={setNodeRef}
+        {...attributes}
+        {...listeners}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default DraggableDayTimelineSchedule;

--- a/frontend/src/features/dayTimeline/components/TimelineSchedules.tsx
+++ b/frontend/src/features/dayTimeline/components/TimelineSchedules.tsx
@@ -1,53 +1,119 @@
-import { DayTimelineSchedule, ScheduleEvent } from "./DayTimelineEvent";
+import { DayTimelineSchedule, ScheduleEvent } from "./DayTimelineSchedule";
 import { useTimelineSettings } from "~/hooks/useTimelineSettings";
+import DraggableDayTimelineSchedule from "./DraggableDayTimelineSchedule";
+import { DndContext, DragOverlay } from "@dnd-kit/core";
+import { useDndEditInTimeline } from "../hooks/useDndEditInTimeline";
+import { doc, Timestamp } from "firebase/firestore";
+import { db } from "~/lib/firebase";
+import useAuthUser from "~/hooks/useAuthUser";
+import { defaultConverter } from "~/lib/firestore/firestore";
+import { useCalendarSession } from "~/hooks/useCalendarSession";
+import { getEndDroppingDate } from "~/app/(app)/(calendar)/calendar/edit/page";
+import { DBEventPoolItem } from "~/lib/firestore/utils";
+import { MutableRefObject, UIEventHandler, useEffect } from "react";
 
 interface TimelineSchedulesProps {
   schedules: ScheduleEvent[];
   currentDate: Date;
+  scrollAreaRef: React.RefObject<HTMLDivElement>;
+  handleScrollStateForDndEditInTimeline: MutableRefObject<UIEventHandler<HTMLDivElement> | null>;
 }
 
 const TimelineSchedules = (props: TimelineSchedulesProps) => {
   const { timelineSettings } = useTimelineSettings();
+  const {
+    dndContextProps,
+    activeId,
+    activeScheduleEvent,
+    quantizedMinutesFromMidnight,
+    handleScroll,
+  } = useDndEditInTimeline({ scrollAreaRef: props.scrollAreaRef });
+  const { calendarSession } = useCalendarSession();
+  const authUser = useAuthUser();
+
+  const droppingDate = new Date(calendarSession.currentDate);
+  droppingDate.setHours(
+    Math.floor(quantizedMinutesFromMidnight / 60),
+    quantizedMinutesFromMidnight % 60
+  );
+
   const getTop = (schedule: ScheduleEvent) => {
     const startDate = schedule.start_time.toDate();
-    console.log(startDate);
-
     const minutesFromMidnight =
       startDate.getHours() * 60 + startDate.getMinutes();
     const top =
       timelineSettings.gridHeight *
       (minutesFromMidnight / (timelineSettings.gridInterval * 60));
-    console.log(top);
     return top;
   };
 
+  useEffect(() => {
+    props.handleScrollStateForDndEditInTimeline.current = handleScroll;
+  }, [handleScroll, props.handleScrollStateForDndEditInTimeline]);
+
   return (
-    <div className="relative w-full h-ful">
-      {props.schedules
-        .filter((schedule) => {
-          const startDate = schedule.start_time.toDate();
-          const condition =
-            startDate.getDate() === props.currentDate.getDate() &&
-            startDate.getMonth() === props.currentDate.getMonth() &&
-            startDate.getFullYear() === props.currentDate.getFullYear();
-          return condition;
-        })
-        .map((schedule) => {
-          return (
-            <div
-              key={schedule.schedule_uid}
-              className="absolute"
-              style={{
-                top: getTop(schedule),
-                left: 24 + 36,
-                width: "min(calc(100% - 76px), 400px)",
-              }}
-            >
-              <DayTimelineSchedule schedule={schedule} />
-            </div>
-          );
-        })}
-    </div>
+    <DndContext {...dndContextProps}>
+      <div className="relative w-full h-ful">
+        {props.schedules
+          .filter((schedule) => {
+            const startDate = schedule.start_time.toDate();
+            const condition =
+              startDate.getDate() === props.currentDate.getDate() &&
+              startDate.getMonth() === props.currentDate.getMonth() &&
+              startDate.getFullYear() === props.currentDate.getFullYear();
+            return condition;
+          })
+          .map((schedule) => {
+            return (
+              <div
+                key={schedule.schedule_uid}
+                className="absolute"
+                style={{
+                  top: getTop(schedule),
+                  left: 24 + 36,
+                  width: "min(calc(100% - 76px), 400px)",
+                }}
+              >
+                <DraggableDayTimelineSchedule
+                  schedule={schedule}
+                  id={schedule.schedule_uid}
+                />
+              </div>
+            );
+          })}
+      </div>
+      <DragOverlay dropAnimation={null}>
+        {activeId ? (
+          <DayTimelineSchedule
+            isDragging
+            schedule={{
+              ...activeScheduleEvent!,
+              event_reference: doc(
+                db,
+                "accounts",
+                authUser !== "loading" ? authUser?.uid ?? "" : "",
+                "event_pool",
+                activeId
+              ).withConverter(defaultConverter<DBEventPoolItem>()),
+              start_time: Timestamp.fromDate(droppingDate),
+              end_time: Timestamp.fromDate(
+                getEndDroppingDate(
+                  calendarSession.currentDate,
+                  quantizedMinutesFromMidnight,
+                  activeScheduleEvent!.default_duration
+                )
+              ),
+              actual_budget:
+                activeScheduleEvent === null
+                  ? { mode: "total", value: 0 }
+                  : activeScheduleEvent.default_budget,
+              did_prepare: false,
+              schedule_uid: activeScheduleEvent?.schedule_uid ?? "",
+            }}
+          />
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
 };
 

--- a/frontend/src/features/dayTimeline/components/TimelineSchedules.tsx
+++ b/frontend/src/features/dayTimeline/components/TimelineSchedules.tsx
@@ -8,10 +8,10 @@ import { db } from "~/lib/firebase";
 import useAuthUser from "~/hooks/useAuthUser";
 import { defaultConverter } from "~/lib/firestore/firestore";
 import { useCalendarSession } from "~/hooks/useCalendarSession";
-import { getEndDroppingDate } from "~/app/(app)/(calendar)/calendar/edit/page";
 import { DBEventPoolItem } from "~/lib/firestore/utils";
 import { MutableRefObject, UIEventHandler, useEffect } from "react";
 import { useOptimisticSchedules } from "~/hooks/useOptimisticSchedules";
+import { getEndDroppingDate } from "../utils/getEndDroppingDate";
 
 interface TimelineSchedulesProps {
   schedules: ScheduleEvent[];

--- a/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
+++ b/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
@@ -61,11 +61,7 @@ export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
     if (activeScheduleEvent) {
       options.onChangeStartTime?.(minute, activeScheduleEvent);
     }
-  }, [
-    activeScheduleEvent,
-    options.onChangeStartTime,
-    quantizedMinutesFromMidnight,
-  ]);
+  }, [activeScheduleEvent, options, quantizedMinutesFromMidnight]);
 
   const scheduleItemModifier: Modifier = useCallback(
     (args) => {
@@ -125,7 +121,7 @@ export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
       onDragEnd: handleDragEnd,
       sensors,
     };
-  }, [handleStartDrag, scheduleItemModifier]);
+  }, [handleDragEnd, handleStartDrag, scheduleItemModifier, sensors]);
 
   const handleScroll: UIEventHandler = (e) => {
     if (e) {

--- a/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
+++ b/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
@@ -31,6 +31,17 @@ export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
     setActiveScheduleEvent(event.active.data.current?.schedule);
   }, []);
 
+  const handleDragEnd = useCallback(() => {
+    const minute = quantizedMinutesFromMidnight;
+    if (activeScheduleEvent) {
+      options.onChangeStartTime?.(minute, activeScheduleEvent);
+    }
+  }, [
+    activeScheduleEvent,
+    options.onChangeStartTime,
+    quantizedMinutesFromMidnight,
+  ]);
+
   const scheduleItemModifier: Modifier = useCallback(
     (args) => {
       scrollAreaRect.current =
@@ -86,6 +97,7 @@ export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
     return {
       modifiers: [scheduleItemModifier],
       onDragStart: handleStartDrag,
+      onDragEnd: handleDragEnd,
     };
   }, [handleStartDrag, scheduleItemModifier]);
 

--- a/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
+++ b/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
@@ -1,4 +1,12 @@
-import { ClientRect, DragStartEvent, Modifier } from "@dnd-kit/core";
+import {
+  ClientRect,
+  DragStartEvent,
+  Modifier,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
 import { Props } from "@dnd-kit/core/dist/components/DndContext/DndContext";
 import { UIEventHandler, useCallback, useMemo, useRef, useState } from "react";
 import { ScheduleEvent } from "../components/DayTimelineSchedule";
@@ -21,6 +29,23 @@ export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
   const scrollTopInDayTimeline = useRef<number | null>(null);
   const [quantizedMinutesFromMidnight, setQuantizedMinutesFromMidnight] =
     useState<number>(0);
+
+  const mouseSensor = useSensor(MouseSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+
+  const touchSensor = useSensor(TouchSensor, {
+    // Press delay of 250ms, with tolerance of 5px of movement
+    activationConstraint: {
+      delay: 250,
+      tolerance: 5,
+    },
+  });
+
+  const sensors = useSensors(mouseSensor, touchSensor);
 
   const handleStartDrag = useCallback((event: DragStartEvent) => {
     console.log(
@@ -98,6 +123,7 @@ export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
       modifiers: [scheduleItemModifier],
       onDragStart: handleStartDrag,
       onDragEnd: handleDragEnd,
+      sensors,
     };
   }, [handleStartDrag, scheduleItemModifier]);
 

--- a/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
+++ b/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
@@ -39,7 +39,7 @@ export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
       let modifiedTransform = args.transform;
 
       const topInDayTimeline =
-        (args.overlayNodeRect?.top ?? 0) + // ドラッグ前の小さいイベントブロックのtop位置
+        (args.activeNodeRect?.top ?? 0) + // ドラッグ前の小さいイベントブロックのtop位置
         args.transform.y + // ドラッグ中のイベントブロックのyデルタ
         (scrollTopInDayTimeline.current ?? 0) - // スクロールエリアのスクロール量
         (scrollAreaRect.current?.top ?? 0) - // スクロールエリアのtop位置
@@ -64,11 +64,11 @@ export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
 
       modifiedTransform = {
         ...modifiedTransform,
-        x: (scrollAreaRect.current?.left ?? 200) - 24 + 60, // グリッドの左端から60px右にずらす
+        x: 0, // ずらさない
         y:
           (quantizedMinutesFromMidnight / 60) * timelineSettings.gridHeight -
           (scrollTopInDayTimeline.current ?? 0) -
-          (args.overlayNodeRect?.top ?? 0) +
+          (args.activeNodeRect?.top ?? 0) +
           (scrollAreaRect.current?.top ?? 0) +
           24,
       };

--- a/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
+++ b/frontend/src/features/dayTimeline/hooks/useDndEditInTimeline.ts
@@ -1,0 +1,105 @@
+import { ClientRect, DragStartEvent, Modifier } from "@dnd-kit/core";
+import { Props } from "@dnd-kit/core/dist/components/DndContext/DndContext";
+import { UIEventHandler, useCallback, useMemo, useRef, useState } from "react";
+import { ScheduleEvent } from "../components/DayTimelineSchedule";
+import { useTimelineSettings } from "~/hooks/useTimelineSettings";
+
+interface UseDndEditInTimelineOptions {
+  onChangeStartTime?: (
+    startMinute: number,
+    scheduleEvent: ScheduleEvent
+  ) => void;
+  scrollAreaRef: React.RefObject<HTMLDivElement>;
+}
+
+export const useDndEditInTimeline = (options: UseDndEditInTimelineOptions) => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeScheduleEvent, setActiveScheduleEvent] =
+    useState<ScheduleEvent | null>(null);
+  const { timelineSettings } = useTimelineSettings();
+  const scrollAreaRect = useRef<ClientRect | null>(null);
+  const scrollTopInDayTimeline = useRef<number | null>(null);
+  const [quantizedMinutesFromMidnight, setQuantizedMinutesFromMidnight] =
+    useState<number>(0);
+
+  const handleStartDrag = useCallback((event: DragStartEvent) => {
+    console.log(
+      "Start dragging as edit in timeline: ",
+      event.active.data.current?.schedule
+    );
+    setActiveId(String(event.active.id));
+    setActiveScheduleEvent(event.active.data.current?.schedule);
+  }, []);
+
+  const scheduleItemModifier: Modifier = useCallback(
+    (args) => {
+      scrollAreaRect.current =
+        options.scrollAreaRef.current?.getBoundingClientRect() ?? null;
+
+      let modifiedTransform = args.transform;
+
+      const topInDayTimeline =
+        (args.overlayNodeRect?.top ?? 0) + // ドラッグ前の小さいイベントブロックのtop位置
+        args.transform.y + // ドラッグ中のイベントブロックのyデルタ
+        (scrollTopInDayTimeline.current ?? 0) - // スクロールエリアのスクロール量
+        (scrollAreaRect.current?.top ?? 0) - // スクロールエリアのtop位置
+        24; // タイムライングリッドの上部の余白
+
+      let minutesFromMidnight = Math.floor(
+        (topInDayTimeline / timelineSettings.gridHeight) *
+          timelineSettings.gridInterval *
+          60
+      );
+
+      minutesFromMidnight =
+        minutesFromMidnight <= 0
+          ? 0
+          : minutesFromMidnight >= 1440
+          ? 1440
+          : minutesFromMidnight;
+
+      setQuantizedMinutesFromMidnight(
+        Math.floor(minutesFromMidnight / 15) * 15
+      );
+
+      modifiedTransform = {
+        ...modifiedTransform,
+        x: (scrollAreaRect.current?.left ?? 200) - 24 + 60, // グリッドの左端から60px右にずらす
+        y:
+          (quantizedMinutesFromMidnight / 60) * timelineSettings.gridHeight -
+          (scrollTopInDayTimeline.current ?? 0) -
+          (args.overlayNodeRect?.top ?? 0) +
+          (scrollAreaRect.current?.top ?? 0) +
+          24,
+      };
+      return modifiedTransform;
+    },
+    [
+      options.scrollAreaRef,
+      quantizedMinutesFromMidnight,
+      timelineSettings.gridHeight,
+      timelineSettings.gridInterval,
+    ]
+  );
+
+  const dndContextProps: Props = useMemo(() => {
+    return {
+      modifiers: [scheduleItemModifier],
+      onDragStart: handleStartDrag,
+    };
+  }, [handleStartDrag, scheduleItemModifier]);
+
+  const handleScroll: UIEventHandler = (e) => {
+    if (e) {
+      scrollTopInDayTimeline.current = e.currentTarget.scrollTop;
+    }
+  };
+
+  return {
+    dndContextProps,
+    activeId,
+    activeScheduleEvent,
+    quantizedMinutesFromMidnight,
+    handleScroll,
+  };
+};

--- a/frontend/src/features/dayTimeline/utils/getEndDroppingDate.ts
+++ b/frontend/src/features/dayTimeline/utils/getEndDroppingDate.ts
@@ -1,0 +1,10 @@
+export const getEndDroppingDate = (
+  currentDate: Date,
+  startMinute: number,
+  duration: number
+) => {
+  const endMinutes = startMinute + duration;
+  const endTime = new Date(currentDate);
+  endTime.setHours(Math.floor(endMinutes / 60), endMinutes % 60);
+  return endTime;
+};

--- a/frontend/src/features/eventPool/EventsPoolListItem.tsx
+++ b/frontend/src/features/eventPool/EventsPoolListItem.tsx
@@ -14,7 +14,7 @@ type Props = {
 } & HTMLAttributes<HTMLDivElement>;
 
 const Component = forwardRef<HTMLDivElement, Props>(function EventPoolItem(
-  { eventPoolItem: eventPoolItem, ...rest }: Props,
+  { eventPoolItem, ...rest }: Props,
   ref
 ) {
   // TODO　現状は開始時間と終了時間から時間帯を表示しているが、今後は平日は何時やいつは何時と表形式にしたい。

--- a/frontend/src/features/eventPool/EventsPoolListItem.tsx
+++ b/frontend/src/features/eventPool/EventsPoolListItem.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { forwardRef, HTMLAttributes } from "react";
+import { forwardRef, HTMLAttributes, useState } from "react";
 import { Hourglass, Map } from "lucide-react";
 import { Card, CardContent } from "~/components/ui/card";
 import { useDraggable } from "@dnd-kit/core";
@@ -7,6 +7,8 @@ import clsx from "clsx";
 import { TimeRange } from "~/models/types/common";
 import { Timestamp } from "firebase/firestore";
 import { DBEventPoolItem } from "~/lib/firestore/utils";
+import EventPoolItemDetails from "./components/EventPoolItemDetails";
+import { Popover, PopoverTrigger } from "~/components/ui/popover";
 
 type Props = {
   id: string;
@@ -50,21 +52,28 @@ const Component = forwardRef<HTMLDivElement, Props>(function EventPoolItem(
 
   return (
     <div className="relative w-[350px]" ref={ref} {...rest}>
-      <Card className="w-[350px]">
-        <CardContent>
-          <h1 className="text-xl font-bold mt-6 mb-4">{eventPoolItem.title}</h1>
-          <div className="col-auto flex flex-col gap-x-0 gap-y-3">
-            <div className="font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70 flex items-start justify-start gap-x-1 text-sm">
-              <Hourglass className="w-3.5 h-3.5 mt-1" />
-              {formatTimes(eventPoolItem.available_times)}
-            </div>
-            <div className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 flex items-center justify-start gap-x-1">
-              <Map className="w-3.5 h-3.5" />
-              {eventPoolItem.location_text}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Card className="w-[350px]">
+            <CardContent>
+              <h1 className="text-xl font-bold mt-6 mb-4">
+                {eventPoolItem.title}
+              </h1>
+              <div className="col-auto flex flex-col gap-x-0 gap-y-3">
+                <div className="font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70 flex items-start justify-start gap-x-1 text-sm">
+                  <Hourglass className="w-3.5 h-3.5 mt-1" />
+                  {formatTimes(eventPoolItem.available_times)}
+                </div>
+                <div className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 flex items-center justify-start gap-x-1">
+                  <Map className="w-3.5 h-3.5" />
+                  {eventPoolItem.location_text}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </PopoverTrigger>
+        <EventPoolItemDetails eventPoolItem={eventPoolItem} />
+      </Popover>
     </div>
   );
 });

--- a/frontend/src/features/eventPool/EventsPoolListItem.tsx
+++ b/frontend/src/features/eventPool/EventsPoolListItem.tsx
@@ -19,6 +19,8 @@ const Component = forwardRef<HTMLDivElement, Props>(function EventPoolItem(
   { eventPoolItem, ...rest }: Props,
   ref
 ) {
+  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+
   // TODO　現状は開始時間と終了時間から時間帯を表示しているが、今後は平日は何時やいつは何時と表形式にしたい。
   const formatTimes = (times: TimeRange[]) => {
     const { start_time, end_time } = times[0] ?? {
@@ -51,10 +53,15 @@ const Component = forwardRef<HTMLDivElement, Props>(function EventPoolItem(
   };
 
   return (
-    <div className="relative w-[350px]" ref={ref} {...rest}>
-      <Popover>
+    <div className="relative w-full" ref={ref} {...rest}>
+      <Popover onOpenChange={setIsDetailsOpen}>
         <PopoverTrigger asChild>
-          <Card className="w-[350px]">
+          <Card
+            className={clsx(
+              "transition-all duration-100",
+              isDetailsOpen ? "shadow-lg" : "shadow-sm"
+            )}
+          >
             <CardContent>
               <h1 className="text-xl font-bold mt-6 mb-4">
                 {eventPoolItem.title}

--- a/frontend/src/features/eventPool/components/EventPoolItemDetails.tsx
+++ b/frontend/src/features/eventPool/components/EventPoolItemDetails.tsx
@@ -1,0 +1,26 @@
+import SmallTitleWithIcon from "~/components/common/SmallTitleWithIcon";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Popover, PopoverContent } from "~/components/ui/popover";
+import { DBEventPoolItem } from "~/lib/firestore/utils";
+
+interface EventPoolItemDetailsProps {
+  eventPoolItem: DBEventPoolItem;
+}
+
+const EventPoolItemDetails = (props: EventPoolItemDetailsProps) => {
+  return (
+    <PopoverContent className="w-80" side={"right"} sideOffset={10}>
+      {/* TODO: 編集とかできるようにする */}
+      <div className="flex flex-col gap-2">
+        <SmallTitleWithIcon title={props.eventPoolItem.title} />
+        <div>{props.eventPoolItem.description}</div>
+        <div>{props.eventPoolItem.location_text}</div>
+        <div>{props.eventPoolItem.preparation_task}</div>
+        <div>{props.eventPoolItem.notes}</div>
+      </div>
+    </PopoverContent>
+  );
+};
+
+export default EventPoolItemDetails;

--- a/frontend/src/features/eventPool/components/EventPoolItemDetails.tsx
+++ b/frontend/src/features/eventPool/components/EventPoolItemDetails.tsx
@@ -1,7 +1,5 @@
 import SmallTitleWithIcon from "~/components/common/SmallTitleWithIcon";
-import { Input } from "~/components/ui/input";
-import { Label } from "~/components/ui/label";
-import { Popover, PopoverContent } from "~/components/ui/popover";
+import { PopoverContent } from "~/components/ui/popover";
 import { DBEventPoolItem } from "~/lib/firestore/utils";
 
 interface EventPoolItemDetailsProps {

--- a/frontend/src/hooks/useDndTimeline.ts
+++ b/frontend/src/hooks/useDndTimeline.ts
@@ -78,16 +78,13 @@ export const useDndTimeline = (options: UseDndTimeLineOptions = {}) => {
     quantizedMinutesFromMidnight,
   ]);
 
-  const setScrollAreaRef = useCallback((node: HTMLDivElement | null) => {
-    scrollAreaRef.current = node;
-    if (node) {
-      scrollAreaRect.current = node.getBoundingClientRect();
-    }
-  }, []);
-
   const eventItemModifier: Modifier = useCallback(
     (args) => {
       let modifiedTransform = args.transform;
+
+      if (scrollAreaRef.current) {
+        scrollAreaRect.current = scrollAreaRef.current.getBoundingClientRect();
+      }
 
       modifierRef.current = args;
 
@@ -159,7 +156,7 @@ export const useDndTimeline = (options: UseDndTimeLineOptions = {}) => {
     minutesFromMidnight,
     topInDayTimeline,
     quantizedMinutesFromMidnight,
-    setScrollAreaRef,
+    scrollAreaRef,
     activeEventPoolItem,
   };
 };

--- a/frontend/src/hooks/useDndTimeline.ts
+++ b/frontend/src/hooks/useDndTimeline.ts
@@ -3,6 +3,10 @@ import {
   DragOverEvent,
   DragStartEvent,
   Modifier,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
 } from "@dnd-kit/core";
 import { UIEventHandler, useCallback, useMemo, useRef, useState } from "react";
 import { useTimelineSettings } from "~/hooks/useTimelineSettings";
@@ -31,6 +35,23 @@ export const useDndTimeline = (options: UseDndTimeLineOptions = {}) => {
     useState<number>(0);
   const scrollAreaRef = useRef<HTMLDivElement | null>(null);
   const scrollAreaRect = useRef<ClientRect | null>(null);
+
+  const mouseSensor = useSensor(MouseSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+
+  const touchSensor = useSensor(TouchSensor, {
+    // Press delay of 250ms, with tolerance of 5px of movement
+    activationConstraint: {
+      delay: 250,
+      tolerance: 5,
+    },
+  });
+
+  const sensors = useSensors(mouseSensor, touchSensor);
 
   const handleStartDrag = useCallback(
     (event: DragStartEvent) => {
@@ -140,8 +161,15 @@ export const useDndTimeline = (options: UseDndTimeLineOptions = {}) => {
       onDragOver: handleDragOver,
       onDragCancel: handleDragCancel,
       onDragEnd: handleDragEnd,
+      sensors: sensors,
     };
-  }, [eventItemModifier, handleStartDrag, handleDragOver, handleDragEnd]);
+  }, [
+    eventItemModifier,
+    handleStartDrag,
+    handleDragOver,
+    handleDragEnd,
+    sensors,
+  ]);
 
   const onScrollDroppableArea: UIEventHandler = useCallback((e) => {
     scrollTopInDayTimeline.current = e.currentTarget.scrollTop;

--- a/frontend/src/hooks/useOptimisticSchedules.ts
+++ b/frontend/src/hooks/useOptimisticSchedules.ts
@@ -1,5 +1,5 @@
 import { useAtom } from "jotai";
-import { ScheduleEvent } from "~/features/dayTimeline/components/DayTimelineEvent";
+import { ScheduleEvent } from "~/features/dayTimeline/components/DayTimelineSchedule";
 import { optimisticSchedulesAtom } from "~/stores/optimisticSchedules";
 
 export const useOptimisticSchedules = () => {

--- a/frontend/src/hooks/useOptimisticSchedules.ts
+++ b/frontend/src/hooks/useOptimisticSchedules.ts
@@ -7,10 +7,7 @@ export const useOptimisticSchedules = () => {
     optimisticSchedulesAtom
   );
 
-  const updateSchedulesFromDB = (
-    schedules: ScheduleEvent[],
-    groupId: string
-  ) => {
+  const setSchedulesFromDB = (schedules: ScheduleEvent[], groupId: string) => {
     setOptimisticSchedules(
       schedules.map((schedule) => ({
         ...schedule,
@@ -30,9 +27,35 @@ export const useOptimisticSchedules = () => {
     return schedule;
   };
 
+  const updateOptimisticSchedule = (
+    schedule_uid: string,
+    data: ScheduleEvent
+  ) => {
+    if (
+      optimisticSchedules.some(
+        (prevSchedule) => prevSchedule.schedule_uid === schedule_uid
+      )
+    ) {
+      setOptimisticSchedules((prev) =>
+        prev.map((prevSchedule) =>
+          prevSchedule.schedule_uid === schedule_uid
+            ? {
+                ...data,
+                isSyncedWithDB: false,
+                groupId: prevSchedule.groupId,
+              }
+            : prevSchedule
+        )
+      );
+    } else {
+      console.log("Schedule not found: ", schedule_uid);
+    }
+  };
+
   return {
     optimisticSchedules,
-    updateSchedulesFromDB,
+    setSchedulesFromDB,
     addOptimisticSchedule,
+    updateOptimisticSchedule,
   };
 };

--- a/frontend/src/stores/optimisticSchedules.ts
+++ b/frontend/src/stores/optimisticSchedules.ts
@@ -1,5 +1,5 @@
 import { atom } from "jotai";
-import { ScheduleEvent } from "~/features/dayTimeline/components/DayTimelineEvent";
+import { ScheduleEvent } from "~/features/dayTimeline/components/DayTimelineSchedule";
 
 export type OptimisticSchedule = ScheduleEvent & {
   groupId: string;


### PR DESCRIPTION
### やったこと
- タイムラインの予定の開始時間をドラッグで編集できるように
- クリックとドラッグの判定を分けて、詳細表示を出す

### やること
- DBとの同期（まだoptimisticSchedulesのJotaiをいじってるだけ）
- 詳細画面をちゃんと作る
  - デザインをちゃんとやる
  - 編集ボタンから編集に入る
  - 削除ボタンから削除できる
  - など

closes #128 